### PR TITLE
use glob.sync instead of nymagfs in requireUtils func to grab utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const nymagfs = require('nymag-fs'),
+const glob = require('glob'),
   path = require('path');
 
 var req = require;
@@ -12,12 +12,20 @@ function setRequire(value) {
   req = value;
 }
 
+// filter out tests from globbed files
+function noTests(filename) {
+  return filename.indexOf('.test.js') === -1;
+}
+
+
 // require each index.js file from each util folder
 function requireUtils() {
-  const utils = nymagfs.getFolders('lib');
+  const utils = glob.sync(path.resolve(__dirname, 'lib', '**', '*.js')).filter(noTests);
 
   utils.forEach(function (util) {
-    module.exports[util] = req(path.resolve(__dirname, 'lib', util));
+    if (path.basename(path.dirname(util)) !== 'lib') {
+      module.exports[path.basename(path.dirname(util))] = req(path.resolve(__dirname, 'lib', path.basename(path.dirname(util), '.js'), 'index'));
+    }
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const glob = require('glob'),
+const nymagfs = require('nymag-fs'),
   path = require('path');
 
 var req = require;
@@ -12,20 +12,12 @@ function setRequire(value) {
   req = value;
 }
 
-// filter out tests from globbed files
-function noTests(filename) {
-  return filename.indexOf('.test.js') === -1;
-}
-
-
 // require each index.js file from each util folder
 function requireUtils() {
-  const utils = glob.sync(path.resolve(__dirname, 'lib', '**', '*.js')).filter(noTests);
+  const utils = nymagfs.getFolders(path.resolve(__dirname, 'lib'));
 
   utils.forEach(function (util) {
-    if (path.basename(path.dirname(util)) !== 'lib') {
-      module.exports[path.basename(path.dirname(util))] = req(path.resolve(__dirname, 'lib', path.basename(path.dirname(util), '.js'), 'index'));
-    }
+    module.exports[util] = req(path.resolve(__dirname, 'lib', util));
   });
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const _ = require('lodash'),
-  glob = require('glob'),
   filename = __filename.split('/').pop().split('.').shift(),
+  nymagfs = require('nymag-fs'),
   expect = require('chai').expect,
   sinon = require('sinon'),
   lib = require('./' + filename);
@@ -30,10 +30,12 @@ describe(_.startCase(filename), function () {
       fakeArr = ['filea', 'fileb', 'filec'];
 
     it('requires each file in the array returned by getFolders', function () {
-      sandbox.stub(glob, 'sync').returns(fakeArr);
+      sandbox.stub(nymagfs, 'getFolders').returns(fakeArr);
+      req.returns('value');
       fn();
 
       expect(req.callCount).to.equal(fakeArr.length);
+      expect(lib['filea']).to.equal('value');
     });
   });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const _ = require('lodash'),
+  glob = require('glob'),
   filename = __filename.split('/').pop().split('.').shift(),
   expect = require('chai').expect,
   sinon = require('sinon'),
-  nymagfs = require('nymag-fs'),
   lib = require('./' + filename);
 
 
@@ -30,12 +30,10 @@ describe(_.startCase(filename), function () {
       fakeArr = ['filea', 'fileb', 'filec'];
 
     it('requires each file in the array returned by getFolders', function () {
-      sandbox.stub(nymagfs, 'getFolders').returns(fakeArr);
-      req.returns('value');
+      sandbox.stub(glob, 'sync').returns(fakeArr);
       fn();
 
       expect(req.callCount).to.equal(fakeArr.length);
-      expect(lib['filea']).to.equal('value');
     });
   });
 });


### PR DESCRIPTION
utils weren't being found when clay-utils was using `nymagfs.getFolders('lib')` to grab the utils from the `lib` directory