### PR TITLE
Removes dynamic requires so module can be bundled

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports.getComponentVersion = require('./lib/getComponentVersion');
 module.exports.getPageInstance = require('./lib/getPageInstance');
 module.exports.isComponent = require('./lib/isComponent');
 module.exports.isDefaultComponent = require('./lib/isDefaultComponent');
-module.exports.isPage = require('./lib/replaceVersion');
+module.exports.isPage = require('./lib/isPage');
+module.exports.isList = require('./lib/isList');
 module.exports.replaceVersion = require('./lib/replaceVersion');

--- a/index.js
+++ b/index.js
@@ -1,28 +1,9 @@
 'use strict';
-
-const nymagfs = require('nymag-fs'),
-  path = require('path');
-
-var req = require;
-
-/**
- * @param {function} value
- */
-function setRequire(value) {
-  req = value;
-}
-
-// require each index.js file from each util folder
-function requireUtils() {
-  const utils = nymagfs.getFolders(path.resolve(__dirname, 'lib'));
-
-  utils.forEach(function (util) {
-    module.exports[util] = req(path.resolve(__dirname, 'lib', util));
-  });
-}
-
-requireUtils();
-module.exports.requireUtils = requireUtils;
-
-// for testing
-module.exports.setRequire = setRequire;
+module.exports.getComponentInstance = require('./lib/getComponentInstance');
+module.exports.getComponentName = require('./lib/getComponentName');
+module.exports.getComponentVersion = require('./lib/getComponentVersion');
+module.exports.getPageInstance = require('./lib/getPageInstance');
+module.exports.isComponent = require('./lib/isComponent');
+module.exports.isDefaultComponent = require('./lib/isDefaultComponent');
+module.exports.isPage = require('./lib/replaceVersion');
+module.exports.replaceVersion = require('./lib/replaceVersion');

--- a/index.test.js
+++ b/index.test.js
@@ -13,7 +13,7 @@ describe(_.startCase(filename), function () {
     fs.readdirSync('./lib')
       .filter(file => fs.statSync('./lib/' + file).isDirectory())
       .forEach((util) => {
-        expect(lib).to.have.property(util);
+        expect(lib[util]).to.eql(require(`./lib/${util}`));
       });
   });
 });

--- a/index.test.js
+++ b/index.test.js
@@ -2,40 +2,18 @@
 
 const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
-  nymagfs = require('nymag-fs'),
   expect = require('chai').expect,
-  sinon = require('sinon'),
-  lib = require('./' + filename);
+  lib = require('./' + filename),
+  fs = require('fs');
 
 
 describe(_.startCase(filename), function () {
-  let req, sandbox;
 
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create();
-
-    // require shouldn't be called dynamically, but here we go
-    req = sandbox.stub();
-    req.resolve = sandbox.stub();
-    lib.setRequire(req);
-  });
-
-  afterEach(function () {
-    sandbox.restore();
-    lib.setRequire(require);
-  });
-
-  describe('requireUtils', function () {
-    const fn = lib[this.title],
-      fakeArr = ['filea', 'fileb', 'filec'];
-
-    it('requires each file in the array returned by getFolders', function () {
-      sandbox.stub(nymagfs, 'getFolders').returns(fakeArr);
-      req.returns('value');
-      fn();
-
-      expect(req.callCount).to.equal(fakeArr.length);
-      expect(lib['filea']).to.equal('value');
-    });
+  it('exports each util in lib', function () {
+    fs.readdirSync('./lib')
+      .filter(file => fs.statSync('./lib/' + file).isDirectory())
+      .forEach((util) => {
+        expect(lib).to.have.property(util);
+      });
   });
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,357 +1,240 @@
 {
   "name": "clay-utils",
   "version": "1.1.1",
-  "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
-      },
+      "version": "3.5.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "dependencies": {
         "assertion-error": {
-          "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-          "dev": true
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
         },
         "deep-eql": {
-          "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-          "dev": true,
-          "requires": {
-            "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-          },
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
           "dependencies": {
             "type-detect": {
-              "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-              "dev": true
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
             }
           }
         },
         "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
-          "dev": true
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
         }
       }
     },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-      },
+      "version": "1.1.3",
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "version": "2.2.1",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "has-ansi": {
-          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-          },
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
             }
           }
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-          },
+          "version": "3.0.1",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
     "coveralls": {
       "version": "2.13.0",
+      "from": "coveralls@>=2.13.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
-      "integrity": "sha1-35M4dujG9HjvsE9NOrcNyWt+Wo4=",
-      "dev": true,
-      "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
-      },
       "dependencies": {
         "js-yaml": {
           "version": "3.6.1",
+          "from": "js-yaml@3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          },
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
+              "from": "argparse@>=1.0.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "1.0.3"
-              },
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-              "dev": true
+              "from": "esprima@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
             }
           }
         },
         "lcov-parse": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-          "dev": true
+          "from": "lcov-parse@0.0.10",
+          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz"
         },
         "log-driver": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
-          "dev": true
+          "from": "log-driver@1.2.5",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz"
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "request": {
           "version": "2.79.0",
+          "from": "request@2.79.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.0.1"
-          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-              "dev": true
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-              "dev": true
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
             },
             "caseless": {
               "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-              "dev": true
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-              "dev": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                  "dev": true
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-              "dev": true
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-              "dev": true
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "2.1.4",
+              "from": "form-data@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-              "dev": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
-              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                  "dev": true
+                  "from": "asynckit@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-              "dev": true,
-              "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.16.0",
-                "pinkie-promise": "2.0.1"
-              },
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
+                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-readlink": "1.0.1"
-                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-                      "dev": true
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.16.0",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-                  "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-                  "dev": true,
-                  "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
-                    "jsonpointer": "4.0.1",
-                    "xtend": "4.0.1"
-                  },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                      "dev": true
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                      "dev": true,
-                      "requires": {
-                        "is-property": "1.0.2"
-                      },
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                          "dev": true
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-                      "dev": true
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                      "dev": true
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                  "dev": true,
-                  "requires": {
-                    "pinkie": "2.0.4"
-                  },
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                      "dev": true
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -359,199 +242,117 @@
             },
             "hawk": {
               "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-              },
               "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
                 "boom": {
                   "version": "2.10.1",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.10.1"
-                  }
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                  "dev": true
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "2.16.3"
-                  }
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-              "dev": true,
-              "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.0"
-              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                  "dev": true
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.4.0",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.0.2",
-                    "json-schema": "0.2.3",
-                    "verror": "1.3.6"
-                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "dev": true
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "extsprintf": {
                       "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                      "dev": true
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                      "dev": true
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                      "dev": true,
-                      "requires": {
-                        "extsprintf": "1.0.2"
-                      }
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.13.0",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-                  "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-                  "dev": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jodid25519": "1.0.2",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                      "dev": true
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "dev": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "0.14.5"
-                      }
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-                      "dev": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-                      "dev": true,
-                      "optional": true
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                      "dev": true,
-                      "optional": true
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                     }
                   }
                 }
@@ -559,1092 +360,774 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-              "dev": true
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-              "dev": true
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-              "dev": true
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.15",
+              "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-              "dev": true,
-              "requires": {
-                "mime-db": "1.27.0"
-              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-                  "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                  "dev": true
+                  "from": "mime-db@>=1.27.0 <1.28.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-              "dev": true
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
               "version": "6.3.2",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-              "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-              "dev": true
+              "from": "qs@>=6.3.0 <6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-              "dev": true
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.3.2",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-              "dev": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                  "dev": true
+                  "from": "punycode@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-              "dev": true
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             },
             "uuid": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-              "dev": true
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
             }
           }
         }
       }
     },
     "eslint": {
-      "version": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-        "espree": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
-        "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
-      },
+      "version": "3.19.0",
+      "from": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "dependencies": {
         "babel-code-frame": {
-          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-          },
+          "version": "6.22.0",
+          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "dependencies": {
             "js-tokens": {
-              "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-              "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-              "dev": true
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
             }
           }
         },
         "concat-stream": {
-          "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-            "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-          },
+          "version": "1.6.0",
+          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "dependencies": {
             "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-              "dev": true,
-              "requires": {
-                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-              },
-              "dependencies": {
-                "buffer-shims": {
-                  "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                  "dev": true
-                },
-                "core-util-is": {
-                  "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                  "dev": true
-                },
-                "isarray": {
-                  "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
-                },
-                "process-nextick-args": {
-                  "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                  "dev": true
-                },
-                "string_decoder": {
-                  "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                  "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-                  "dev": true,
-                  "requires": {
-                    "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                  "dev": true
-                }
-              }
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "typedarray": {
-              "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-              "dev": true
+              "version": "0.0.6",
+              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
             }
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-          "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
-          },
+          "version": "2.6.4",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
           "dependencies": {
             "ms": {
-              "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-              "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
-              "dev": true
+              "version": "0.7.3",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
             }
           }
         },
         "doctrine": {
-          "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-          "dev": true,
-          "requires": {
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-          },
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
           "dependencies": {
             "isarray": {
-              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             }
           }
         },
         "escope": {
-          "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-          "dev": true,
-          "requires": {
-            "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-            "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-            "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-          },
+          "version": "3.6.0",
+          "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
           "dependencies": {
             "es6-map": {
-              "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-              "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-              "dev": true,
-              "requires": {
-                "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-              },
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
               "dependencies": {
                 "d": {
-                  "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                  "dev": true,
-                  "requires": {
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                  }
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                 },
                 "es5-ext": {
-                  "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                  "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-                  "dev": true,
-                  "requires": {
-                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                  }
+                  "version": "0.10.15",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
                 },
                 "es6-iterator": {
-                  "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-                  "dev": true,
-                  "requires": {
-                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                  }
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
                 },
                 "es6-set": {
-                  "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                  "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-                  "dev": true,
-                  "requires": {
-                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                    "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-                  }
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
                 },
                 "es6-symbol": {
-                  "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                  "dev": true,
-                  "requires": {
-                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                  }
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
                 },
                 "event-emitter": {
-                  "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                  "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-                  "dev": true,
-                  "requires": {
-                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                  }
+                  "version": "0.3.5",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
                 }
               }
             },
             "es6-weak-map": {
-              "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-              "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-              "dev": true,
-              "requires": {
-                "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-              },
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
               "dependencies": {
                 "d": {
-                  "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-                  "dev": true,
-                  "requires": {
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                  }
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
                 },
                 "es5-ext": {
-                  "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                  "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
-                  "dev": true,
-                  "requires": {
-                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                  }
+                  "version": "0.10.15",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
                 },
                 "es6-iterator": {
-                  "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-                  "dev": true,
-                  "requires": {
-                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                  }
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
                 },
                 "es6-symbol": {
-                  "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-                  "dev": true,
-                  "requires": {
-                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
-                  }
+                  "version": "3.1.1",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
                 }
               }
             },
             "esrecurse": {
-              "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-              "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-              "dev": true,
-              "requires": {
-                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-              },
+              "version": "4.1.0",
+              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
               "dependencies": {
                 "estraverse": {
-                  "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-                  "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-                  "dev": true
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
                 },
                 "object-assign": {
-                  "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                  "dev": true
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                 }
               }
             }
           }
         },
         "espree": {
-          "version": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
-          "integrity": "sha1-ONve2+3JW4lhofvwRzSo9qnIxZI=",
-          "dev": true,
-          "requires": {
-            "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-            "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-          },
+          "version": "3.4.2",
+          "from": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
           "dependencies": {
             "acorn": {
-              "version": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-              "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
-              "dev": true
+              "version": "5.0.3",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz"
             },
             "acorn-jsx": {
-              "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-              "dev": true,
-              "requires": {
-                "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-              },
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                  "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                  "dev": true
+                  "version": "3.3.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
                 }
               }
             }
           }
         },
         "esquery": {
-          "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-          "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-          "dev": true,
-          "requires": {
-            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-          }
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz"
         },
         "estraverse": {
-          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
+          "version": "4.2.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
         },
         "esutils": {
-          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-          "dev": true
+          "version": "2.0.2",
+          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "file-entry-cache": {
-          "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-          "dev": true,
-          "requires": {
-            "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-          },
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
           "dependencies": {
             "flat-cache": {
-              "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-              "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-              "dev": true,
-              "requires": {
-                "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-                "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-              },
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
               "dependencies": {
                 "circular-json": {
-                  "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-                  "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
-                  "dev": true
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
                 },
                 "del": {
-                  "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                  "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-                  "dev": true,
-                  "requires": {
-                    "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                    "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                    "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                    "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-                  },
+                  "version": "2.2.2",
+                  "from": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
                   "dependencies": {
                     "globby": {
-                      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-                      "dev": true,
-                      "requires": {
-                        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                      },
+                      "version": "5.0.0",
+                      "from": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
                       "dependencies": {
                         "array-union": {
-                          "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-                          "dev": true,
-                          "requires": {
-                            "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-                          },
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
                           "dependencies": {
                             "array-uniq": {
-                              "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-                              "dev": true
+                              "version": "1.0.3",
+                              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
                             }
                           }
                         },
                         "arrify": {
-                          "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-                          "dev": true
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                         }
                       }
                     },
                     "is-path-cwd": {
-                      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-                      "dev": true
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
                     },
                     "is-path-in-cwd": {
-                      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-                      "dev": true,
-                      "requires": {
-                        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-                      },
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
                       "dependencies": {
                         "is-path-inside": {
-                          "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                          "dev": true,
-                          "requires": {
-                            "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-                          }
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
                         }
                       }
                     },
                     "pify": {
-                      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                      "dev": true
+                      "version": "2.3.0",
+                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                     },
                     "pinkie-promise": {
-                      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                      "dev": true,
-                      "requires": {
-                        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                      },
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
-                          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                          "dev": true
+                          "version": "2.0.4",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
                     },
                     "rimraf": {
-                      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-                      "dev": true,
-                      "requires": {
-                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-                      }
+                      "version": "2.6.1",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                  "dev": true
+                  "version": "4.1.11",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                 },
                 "write": {
-                  "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                  "dev": true,
-                  "requires": {
-                    "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                  }
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
                 }
               }
             },
             "object-assign": {
-              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
+              "version": "4.1.1",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
             }
           }
         },
         "globals": {
-          "version": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-          "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
-          "dev": true
+          "version": "9.17.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
         },
         "ignore": {
-          "version": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-          "integrity": "sha1-SBDKXx2OylWVITo0uU8utO2Sa70=",
-          "dev": true
+          "version": "3.2.7",
+          "from": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz"
         },
         "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
+          "version": "0.1.4",
+          "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
         },
         "inquirer": {
-          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-            "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-            "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-            "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-          },
+          "version": "0.12.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "dependencies": {
             "ansi-escapes": {
-              "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-              "dev": true
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
             },
             "ansi-regex": {
-              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
             },
             "cli-cursor": {
-              "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-              "dev": true,
-              "requires": {
-                "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
-              },
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "dependencies": {
                 "restore-cursor": {
-                  "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                  "dev": true,
-                  "requires": {
-                    "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                    "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                  },
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
                   "dependencies": {
                     "exit-hook": {
-                      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-                      "dev": true
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
-                      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                      "dev": true
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
                 }
               }
             },
             "cli-width": {
-              "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-              "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-              "dev": true
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
             },
             "figures": {
-              "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-              "dev": true,
-              "requires": {
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-              },
+              "version": "1.7.0",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
               "dependencies": {
                 "escape-string-regexp": {
-                  "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "dev": true
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "object-assign": {
-                  "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                  "dev": true
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
                 }
               }
             },
             "readline2": {
-              "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-              },
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
-                  "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                 },
                 "is-fullwidth-code-point": {
-                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                  },
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                      "dev": true
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     }
                   }
                 },
                 "mute-stream": {
-                  "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-                  "dev": true
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                 }
               }
             },
             "run-async": {
-              "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-              "dev": true,
-              "requires": {
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-              },
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "dependencies": {
                 "once": {
-                  "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                  },
+                  "version": "1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
               }
             },
             "rx-lite": {
-              "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-              "dev": true
+              "version": "3.1.2",
+              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
             },
             "string-width": {
-              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-              },
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dependencies": {
                 "code-point-at": {
-                  "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                 },
                 "is-fullwidth-code-point": {
-                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "dev": true,
-                  "requires": {
-                    "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                  },
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                      "dev": true
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "strip-ansi": {
-              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-              }
+              "version": "3.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
             },
             "through": {
-              "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-              "dev": true
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "is-my-json-valid": {
-          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-          "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-          "dev": true,
-          "requires": {
-            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-          },
+          "version": "2.16.0",
+          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
           "dependencies": {
             "generate-function": {
-              "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-              "dev": true
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
             },
             "generate-object-property": {
-              "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-              "dev": true,
-              "requires": {
-                "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-              },
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
               "dependencies": {
                 "is-property": {
-                  "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                  "dev": true
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 }
               }
             },
             "jsonpointer": {
-              "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-              "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-              "dev": true
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
             },
             "xtend": {
-              "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-              "dev": true
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "is-resolvable": {
-          "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-          "dev": true,
-          "requires": {
-            "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-          },
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
           "dependencies": {
             "tryit": {
-              "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-              "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-              "dev": true
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
             }
           }
         },
         "js-yaml": {
-          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-          "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
-          "dev": true,
-          "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
-          },
+          "version": "3.8.3",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
           "dependencies": {
             "argparse": {
-              "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-              },
+              "version": "1.0.9",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "dependencies": {
                 "sprintf-js": {
-                  "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
-              "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-              "dev": true
+              "version": "3.1.3",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
             }
           }
         },
         "json-stable-stringify": {
-          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-          },
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "dependencies": {
             "jsonify": {
-              "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             }
           }
         },
         "levn": {
-          "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-          },
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "dependencies": {
             "prelude-ls": {
-              "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-              "dev": true
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
             "type-check": {
-              "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-              }
+              "version": "0.3.2",
+              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
             }
           }
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          },
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "natural-compare": {
-          "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-          "dev": true
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
         },
         "optionator": {
-          "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "dev": true,
-          "requires": {
-            "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-            "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-          },
+          "version": "0.8.2",
+          "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
           "dependencies": {
-            "deep-is": {
-              "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-              "dev": true
-            },
-            "fast-levenshtein": {
-              "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-              "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-              "dev": true
-            },
             "prelude-ls": {
-              "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-              "dev": true
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
             },
-            "type-check": {
-              "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-              }
+            "deep-is": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
             "wordwrap": {
-              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-              "dev": true
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
             }
           }
         },
         "path-is-inside": {
-          "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-          "dev": true
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
         },
         "pluralize": {
-          "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-          "dev": true
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
         },
         "progress": {
-          "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
+          "version": "1.1.8",
+          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
         },
         "require-uncached": {
-          "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-          "dev": true,
-          "requires": {
-            "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-            "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-          },
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
           "dependencies": {
             "caller-path": {
-              "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-              "dev": true,
-              "requires": {
-                "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-              },
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
               "dependencies": {
                 "callsites": {
-                  "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                  "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                  "dev": true
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
                 }
               }
             },
             "resolve-from": {
-              "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-              "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-              "dev": true
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
             }
           }
         },
         "shelljs": {
-          "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-          "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
-          "dev": true,
-          "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-            "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-            "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-          },
+          "version": "0.7.7",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
           "dependencies": {
             "interpret": {
-              "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-              "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
-              "dev": true
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
             },
             "rechoir": {
-              "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-              "dev": true,
-              "requires": {
-                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
-              },
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
               "dependencies": {
                 "resolve": {
-                  "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-                  "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-                  "dev": true,
-                  "requires": {
-                    "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-                  },
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
                   "dependencies": {
                     "path-parse": {
-                      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-                      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-                      "dev": true
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
                     }
                   }
                 }
@@ -1653,80 +1136,61 @@
           }
         },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "version": "3.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
         },
         "strip-json-comments": {
-          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
         },
         "table": {
-          "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-          "dev": true,
-          "requires": {
-            "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
-            "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
-          },
+          "version": "3.8.3",
+          "from": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
           "dependencies": {
             "ajv": {
-              "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
-              "integrity": "sha1-hlWl2G0IJJhcxHGh2RP7Zymg7Eg=",
-              "dev": true,
-              "requires": {
-                "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-              },
+              "version": "4.11.7",
+              "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
               "dependencies": {
                 "co": {
-                  "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                  "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                  "dev": true
+                  "version": "4.6.0",
+                  "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                 }
               }
             },
             "ajv-keywords": {
-              "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-              "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-              "dev": true
+              "version": "1.5.1",
+              "from": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
             },
             "slice-ansi": {
-              "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-              "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-              "dev": true
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
             },
             "string-width": {
-              "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-              "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-              },
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
               "dependencies": {
                 "is-fullwidth-code-point": {
-                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                  "dev": true
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
                 },
                 "strip-ansi": {
-                  "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                  },
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                      "dev": true
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 }
@@ -1735,1059 +1199,825 @@
           }
         },
         "text-table": {
-          "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-          "dev": true
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
         },
         "user-home": {
-          "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-          },
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "dependencies": {
             "os-homedir": {
-              "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "dev": true
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
             }
           }
         }
       }
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "requires": {
-        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      },
+      "version": "7.1.1",
+      "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "dependencies": {
         "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
         },
         "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          },
+          "version": "1.0.6",
+          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "dependencies": {
             "wrappy": {
-              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
             }
           }
         },
         "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-          },
+          "version": "3.0.3",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dependencies": {
             "brace-expansion": {
-              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-              "requires": {
-                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-              },
+              "version": "1.1.7",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
               "dependencies": {
                 "balanced-match": {
-                  "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                 },
                 "concat-map": {
-                  "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          },
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "dependencies": {
             "wrappy": {
-              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
             }
           }
         },
         "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
         }
       }
     },
     "handlebars": {
-      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
-      "dev": true,
-      "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
-      },
+      "version": "4.0.6",
+      "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "version": "1.5.2",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "optimist": {
-          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-          },
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
-            "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-              "dev": true
-            },
             "wordwrap": {
-              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-              "dev": true
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-          },
+          "version": "0.4.4",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-              "dev": true
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
             }
           }
         },
         "uglify-js": {
-          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
-          "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-          },
+          "version": "2.8.22",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
           "dependencies": {
             "source-map": {
-              "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-              "dev": true,
-              "optional": true
-            },
-            "uglify-to-browserify": {
-              "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-              "dev": true,
-              "optional": true
+              "version": "0.5.6",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
             },
             "yargs": {
-              "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-              },
+              "version": "3.10.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                  "dev": true,
-                  "optional": true
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
-                  "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                    "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                    "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                  },
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
-                      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                      },
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
-                          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                          },
+                          "version": "0.1.4",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                              "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                              },
+                              "version": "3.2.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                  "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-                                  "dev": true,
-                                  "optional": true
+                                  "version": "1.1.5",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
                                 }
                               }
                             },
                             "longest": {
-                              "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                              "dev": true,
-                              "optional": true
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
-                              "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                              "dev": true,
-                              "optional": true
+                              "version": "1.6.1",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
-                          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-                          "dev": true,
-                          "optional": true
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                         }
                       }
                     },
                     "right-align": {
-                      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-                      },
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
-                          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                          },
+                          "version": "0.1.4",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
-                              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                              "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                              },
+                              "version": "3.2.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                  "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-                                  "dev": true,
-                                  "optional": true
+                                  "version": "1.1.5",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
                                 }
                               }
                             },
                             "longest": {
-                              "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                              "dev": true,
-                              "optional": true
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
-                              "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                              "dev": true,
-                              "optional": true
+                              "version": "1.6.1",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                             }
                           }
                         }
                       }
                     },
                     "wordwrap": {
-                      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                      "dev": true,
-                      "optional": true
+                      "version": "0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                  "dev": true,
-                  "optional": true
+                  "version": "1.2.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
-                  "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                  "dev": true,
-                  "optional": true
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
         }
       }
     },
     "istanbul": {
-      "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
-      "requires": {
-        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-      },
+      "version": "0.4.5",
+      "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "dependencies": {
         "abbrev": {
-          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
+          "version": "1.0.9",
+          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
         },
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
+          "version": "1.5.2",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "escodegen": {
-          "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-          "dev": true,
-          "requires": {
-            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
-          },
+          "version": "1.8.1",
+          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
           "dependencies": {
             "estraverse": {
-              "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-              "dev": true
+              "version": "1.9.3",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
             "esutils": {
-              "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-              "dev": true
+              "version": "2.0.2",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "optionator": {
-              "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-              "dev": true,
-              "requires": {
-                "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-              },
+              "version": "0.8.2",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
               "dependencies": {
-                "deep-is": {
-                  "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-                  "dev": true
-                },
-                "fast-levenshtein": {
-                  "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                  "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-                  "dev": true
-                },
-                "levn": {
-                  "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                  "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                  }
-                },
                 "prelude-ls": {
-                  "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                  "dev": true
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                 },
                 "type-check": {
-                  "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                  }
+                  "version": "0.3.2",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                },
+                "levn": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "2.0.6",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
                 }
               }
             },
             "source-map": {
-              "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-              },
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-                  "dev": true,
-                  "optional": true
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
                 }
               }
             }
           }
         },
         "esprima": {
-          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
+          "version": "2.7.3",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-          },
+          "version": "5.0.15",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
-              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "dev": true,
-              "requires": {
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-              },
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-              },
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-                  "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                    "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                  },
+                  "version": "1.1.7",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                      "dev": true
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
-                      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
                 }
               }
             },
             "path-is-absolute": {
-              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "js-yaml": {
-          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-          "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
-          "dev": true,
-          "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
-          },
+          "version": "3.8.3",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
           "dependencies": {
             "argparse": {
-              "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-              "dev": true,
-              "requires": {
-                "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-              },
+              "version": "1.0.9",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "dependencies": {
                 "sprintf-js": {
-                  "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                  "dev": true
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
-              "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-              "dev": true
+              "version": "3.1.3",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
             }
           }
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          },
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-          }
+          "version": "3.0.6",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          },
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "dependencies": {
             "wrappy": {
-              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
             }
           }
         },
         "resolve": {
-          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "version": "1.1.7",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-          },
+          "version": "3.2.3",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dependencies": {
             "has-flag": {
-              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-              "dev": true
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-          },
+          "version": "1.2.14",
+          "from": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "dependencies": {
             "isexe": {
-              "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
             }
           }
         },
         "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
         }
       }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.4",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
-      "integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
-      },
+      "version": "3.3.0",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
       "dependencies": {
         "browser-stdout": {
-          "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-          "dev": true
+          "version": "1.3.0",
+          "from": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
         },
         "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-          },
+          "version": "2.9.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
-              "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-              "dev": true
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-          },
+          "version": "2.6.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "dependencies": {
             "ms": {
-              "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
+              "version": "0.7.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
             }
           }
         },
         "diff": {
-          "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-          "dev": true
+          "version": "3.2.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
         },
         "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "version": "1.0.5",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "growl": {
-          "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-          "dev": true
+          "version": "1.9.2",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
         },
         "json3": {
-          "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-          "dev": true
+          "version": "3.3.2",
+          "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
         },
         "lodash.create": {
-          "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-          "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-          "dev": true,
-          "requires": {
-            "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-            "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-          },
+          "version": "3.1.1",
+          "from": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
           "dependencies": {
             "lodash._baseassign": {
-              "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-              "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-              "dev": true,
-              "requires": {
-                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
-              },
+              "version": "3.2.0",
+              "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
-                  "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-                  "dev": true
+                  "version": "3.0.1",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 },
                 "lodash.keys": {
-                  "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-                  "dev": true,
-                  "requires": {
-                    "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                    "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                    "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                  },
+                  "version": "3.1.2",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-                      "dev": true
+                      "version": "3.9.1",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
-                      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-                      "dev": true
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
                     },
                     "lodash.isarray": {
-                      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-                      "dev": true
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 }
               }
             },
             "lodash._basecreate": {
-              "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-              "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-              "dev": true
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
             },
             "lodash._isiterateecall": {
-              "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-              "dev": true
+              "version": "3.0.9",
+              "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
             }
           }
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-          },
+          "version": "0.5.1",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-          },
+          "version": "3.1.2",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
-              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-              "dev": true
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "nymag-fs": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.0.tgz",
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.8.3",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "3.1.3",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
             }
           }
         }
       }
     },
     "pre-commit": {
-      "version": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-      },
+      "version": "1.2.2",
+      "from": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
       "dependencies": {
         "cross-spawn": {
-          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-            "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-          },
+          "version": "5.1.0",
+          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-              "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-              "dev": true,
-              "requires": {
-                "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-              },
+              "version": "4.0.2",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
               "dependencies": {
                 "pseudomap": {
-                  "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-                  "dev": true
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                 },
                 "yallist": {
-                  "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-                  "dev": true
+                  "version": "2.1.2",
+                  "from": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
                 }
               }
             },
             "shebang-command": {
-              "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-              "dev": true,
-              "requires": {
-                "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-              },
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
               "dependencies": {
                 "shebang-regex": {
-                  "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-                  "dev": true
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
                 }
               }
             }
           }
         },
         "spawn-sync": {
-          "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-          "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-            "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
-          },
+          "version": "1.0.15",
+          "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
           "dependencies": {
             "concat-stream": {
-              "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-              "dev": true,
-              "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-              },
+              "version": "1.6.0",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                  "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-                  "dev": true,
-                  "requires": {
-                    "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                  },
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                      "dev": true
-                    },
-                    "core-util-is": {
-                      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
-                    },
-                    "process-nextick-args": {
-                      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-                      "dev": true,
-                      "requires": {
-                        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                      }
-                    },
-                    "util-deprecate": {
-                      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
-                    }
-                  }
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "typedarray": {
-                  "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
                 }
               }
             },
             "os-shim": {
-              "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-              "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-              "dev": true
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
             }
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-          },
+          "version": "1.2.14",
+          "from": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "dependencies": {
             "isexe": {
-              "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-              "dev": true
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
             }
           }
         }
       }
     },
     "sinon": {
-      "version": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
-      "integrity": "sha1-4Fep0r8bMvXW3WJijKnuOWGwyvs=",
-      "dev": true,
-      "requires": {
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "formatio": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-        "lolex": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-        "native-promise-only": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-        "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
-      },
+      "version": "2.1.0",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
       "dependencies": {
         "diff": {
-          "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-          "dev": true
+          "version": "3.2.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
         },
         "formatio": {
-          "version": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-          "dev": true,
-          "requires": {
-            "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
-          }
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz"
         },
         "lolex": {
-          "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
+          "version": "1.6.0",
+          "from": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz"
         },
         "native-promise-only": {
-          "version": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-          "dev": true
+          "version": "0.8.1",
+          "from": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz"
         },
         "path-to-regexp": {
-          "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-          },
+          "version": "1.7.0",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "dependencies": {
             "isarray": {
-              "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "samsam": {
-          "version": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-          "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
-          "dev": true
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
         },
         "text-encoding": {
-          "version": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-          "dev": true
+          "version": "0.6.4",
+          "from": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz"
         },
         "type-detect": {
-          "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
-          "dev": true
+          "version": "4.0.3",
+          "from": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
         }
       }
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,240 +1,357 @@
 {
   "name": "clay-utils",
   "version": "1.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "chai": {
-      "version": "3.5.0",
-      "from": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+      },
       "dependencies": {
         "assertion-error": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
+          "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+          "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+          "dev": true
         },
         "deep-eql": {
-          "version": "0.1.3",
-          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+          },
           "dependencies": {
             "type-detect": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+              "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
             }
           }
         },
         "type-detect": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+          "dev": true
         }
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      },
       "dependencies": {
         "ansi-styles": {
-          "version": "2.2.1",
-          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
             }
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          },
           "dependencies": {
             "ansi-regex": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
             }
           }
         },
         "supports-color": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
     "coveralls": {
       "version": "2.13.0",
-      "from": "coveralls@>=2.13.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.0.tgz",
+      "integrity": "sha1-35M4dujG9HjvsE9NOrcNyWt+Wo4=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
       "dependencies": {
         "js-yaml": {
           "version": "3.6.1",
-          "from": "js-yaml@3.6.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.3"
+          },
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
-              "from": "argparse@>=1.0.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
                 }
               }
             },
             "esprima": {
               "version": "2.7.3",
-              "from": "esprima@>=2.6.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
             }
           }
         },
         "lcov-parse": {
           "version": "0.0.10",
-          "from": "lcov-parse@0.0.10",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz"
+          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+          "dev": true
         },
         "log-driver": {
           "version": "1.2.5",
-          "from": "log-driver@1.2.5",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz"
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+          "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "request": {
           "version": "2.79.0",
-          "from": "request@2.79.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.0.1"
+          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "dev": true
             },
             "aws4": {
               "version": "1.6.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+              "dev": true
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true
             },
             "form-data": {
               "version": "2.1.4",
-              "from": "form-data@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+              "dev": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                  "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "dev": true,
+              "requires": {
+                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.16.0",
+                "pinkie-promise": "2.0.1"
+              },
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "dev": true
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.16.0",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+                  "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+                  "dev": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "4.0.1",
+                    "xtend": "4.0.1"
+                  },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "dev": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "dev": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "dev": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "4.0.1",
-                      "from": "jsonpointer@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+                      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+                      "dev": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "dev": true
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "dev": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "dev": true
                     }
                   }
                 }
@@ -242,117 +359,199 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "dev": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
               "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "dev": true
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "dev": true
                 },
                 "jsprim": {
                   "version": "1.4.0",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+                  "dev": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                      "dev": true
                     },
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                      "dev": true
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "dev": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.13.0",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                  "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+                  "dev": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "dev": true
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                      "dev": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 }
@@ -360,774 +559,1092 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+              "dev": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.27.0",
-                  "from": "mime-db@>=1.27.0 <1.28.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                  "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                  "dev": true
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "dev": true
             },
             "qs": {
               "version": "6.3.2",
-              "from": "qs@>=6.3.0 <6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+              "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+              "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "dev": true
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+              "dev": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "from": "punycode@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                  "dev": true
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+              "dev": true
             },
             "uuid": {
               "version": "3.0.1",
-              "from": "uuid@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+              "dev": true
             }
           }
         }
       }
     },
     "eslint": {
-      "version": "3.19.0",
-      "from": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "version": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+        "espree": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+        "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+      },
       "dependencies": {
         "babel-code-frame": {
-          "version": "6.22.0",
-          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+          },
           "dependencies": {
             "js-tokens": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+              "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+              "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+              "dev": true
             }
           }
         },
         "concat-stream": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+            "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+          },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
             },
             "readable-stream": {
-              "version": "2.2.9",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+              "dev": true,
+              "requires": {
+                "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+              },
               "dependencies": {
                 "buffer-shims": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                  "dev": true
                 },
                 "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
                 },
                 "isarray": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                  "dev": true
                 },
                 "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                  "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                  "dev": true
                 },
                 "string_decoder": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                  "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                  "dev": true,
+                  "requires": {
+                    "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                  }
                 },
                 "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                  "dev": true
                 }
               }
+            },
+            "typedarray": {
+              "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+              "dev": true
             }
           }
         },
         "debug": {
-          "version": "2.6.4",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
+          "integrity": "sha1-dYaps8OXQcAoKuM0RcTorHRzT+A=",
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+          },
           "dependencies": {
             "ms": {
-              "version": "0.7.3",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz"
+              "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+              "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
+              "dev": true
             }
           }
         },
         "doctrine": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+          "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+          "dev": true,
+          "requires": {
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          },
           "dependencies": {
             "isarray": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "dev": true
             }
           }
         },
         "escope": {
-          "version": "3.6.0",
-          "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+          "dev": true,
+          "requires": {
+            "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+            "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+          },
           "dependencies": {
             "es6-map": {
-              "version": "0.1.5",
-              "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+              "dev": true,
+              "requires": {
+                "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+              },
               "dependencies": {
                 "d": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  }
                 },
                 "es5-ext": {
-                  "version": "0.10.15",
-                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                  "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  }
                 },
                 "es6-iterator": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+                  "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+                  "dev": true,
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  }
                 },
                 "es6-set": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
+                  "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+                  "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+                  "dev": true,
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                    "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+                  }
                 },
                 "es6-symbol": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                  "dev": true,
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  }
                 },
                 "event-emitter": {
-                  "version": "0.3.5",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+                  "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+                  "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+                  "dev": true,
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  }
                 }
               }
             },
             "es6-weak-map": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+              "dev": true,
+              "requires": {
+                "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+              },
               "dependencies": {
                 "d": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  }
                 },
                 "es5-ext": {
-                  "version": "0.10.15",
-                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                  "integrity": "sha1-wzClk0we4hKEp8CBqG5f2TfJHqY=",
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  }
                 },
                 "es6-iterator": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+                  "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+                  "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+                  "dev": true,
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz",
+                    "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  }
                 },
                 "es6-symbol": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                  "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                  "dev": true,
+                  "requires": {
+                    "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+                    "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.15.tgz"
+                  }
                 }
               }
             },
             "esrecurse": {
-              "version": "4.1.0",
-              "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+              "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+              "dev": true,
+              "requires": {
+                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+              },
               "dependencies": {
                 "estraverse": {
-                  "version": "4.1.1",
-                  "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+                  "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                  "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+                  "dev": true
                 },
                 "object-assign": {
-                  "version": "4.1.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                  "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
                 }
               }
             }
           }
         },
         "espree": {
-          "version": "3.4.2",
-          "from": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+          "version": "https://registry.npmjs.org/espree/-/espree-3.4.2.tgz",
+          "integrity": "sha1-ONve2+3JW4lhofvwRzSo9qnIxZI=",
+          "dev": true,
+          "requires": {
+            "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+            "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+          },
           "dependencies": {
             "acorn": {
-              "version": "5.0.3",
-              "from": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz"
+              "version": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+              "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+              "dev": true
             },
             "acorn-jsx": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+              "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+              "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+              "dev": true,
+              "requires": {
+                "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+              },
               "dependencies": {
                 "acorn": {
-                  "version": "3.3.0",
-                  "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+                  "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                  "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                  "dev": true
                 }
               }
             }
           }
         },
         "esquery": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+          "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+          "dev": true,
+          "requires": {
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+          }
         },
         "estraverse": {
-          "version": "4.2.0",
-          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
         },
         "esutils": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
         },
         "file-entry-cache": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+          },
           "dependencies": {
             "flat-cache": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+              "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+              "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+              "dev": true,
+              "requires": {
+                "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+                "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+              },
               "dependencies": {
                 "circular-json": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
+                  "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+                  "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+                  "dev": true
                 },
                 "del": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                  "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                  "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                  "dev": true,
+                  "requires": {
+                    "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                    "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                    "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                    "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                  },
                   "dependencies": {
                     "globby": {
-                      "version": "5.0.0",
-                      "from": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                      "dev": true,
+                      "requires": {
+                        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+                      },
                       "dependencies": {
                         "array-union": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                          "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                          "dev": true,
+                          "requires": {
+                            "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+                          },
                           "dependencies": {
                             "array-uniq": {
-                              "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+                              "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                              "dev": true
                             }
                           }
                         },
                         "arrify": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                          "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                          "dev": true
                         }
                       }
                     },
                     "is-path-cwd": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+                      "dev": true
                     },
                     "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+                      "dev": true,
+                      "requires": {
+                        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                      },
                       "dependencies": {
                         "is-path-inside": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                          "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                          "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+                          "dev": true,
+                          "requires": {
+                            "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+                          }
                         }
                       }
                     },
                     "pify": {
-                      "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "dev": true
                     },
                     "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "requires": {
+                        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                      },
                       "dependencies": {
                         "pinkie": {
-                          "version": "2.0.4",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true
                         }
                       }
                     },
                     "rimraf": {
-                      "version": "2.6.1",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+                      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+                      "dev": true,
+                      "requires": {
+                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+                      }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "4.1.11",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                  "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                  "dev": true
                 },
                 "write": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                  "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                  "dev": true,
+                  "requires": {
+                    "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                  }
                 }
               }
             },
             "object-assign": {
-              "version": "4.1.1",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "dev": true
             }
           }
         },
         "globals": {
-          "version": "9.17.0",
-          "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
+          "version": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
+          "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+          "dev": true
         },
         "ignore": {
-          "version": "3.2.7",
-          "from": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz"
+          "version": "https://registry.npmjs.org/ignore/-/ignore-3.2.7.tgz",
+          "integrity": "sha1-SBDKXx2OylWVITo0uU8utO2Sa70=",
+          "dev": true
         },
         "imurmurhash": {
-          "version": "0.1.4",
-          "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "dev": true
         },
         "inquirer": {
-          "version": "0.12.0",
-          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+            "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+            "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+            "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+            "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+          },
           "dependencies": {
             "ansi-escapes": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+              "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+              "dev": true
             },
             "ansi-regex": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
             },
             "cli-cursor": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "dev": true,
+              "requires": {
+                "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+              },
               "dependencies": {
                 "restore-cursor": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                  "dev": true,
+                  "requires": {
+                    "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                    "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                  },
                   "dependencies": {
                     "exit-hook": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+                      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+                      "dev": true
                     },
                     "onetime": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                      "dev": true
                     }
                   }
                 }
               }
             },
             "cli-width": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
+              "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+              "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+              "dev": true
             },
             "figures": {
-              "version": "1.7.0",
-              "from": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "dev": true,
+              "requires": {
+                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+              },
               "dependencies": {
                 "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                  "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
                 },
                 "object-assign": {
-                  "version": "4.1.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                  "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
                 }
               }
             },
             "readline2": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+              },
               "dependencies": {
                 "code-point-at": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                  "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                  "dev": true
                 },
                 "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                  },
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
                     }
                   }
                 },
                 "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                  "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+                  "dev": true
                 }
               }
             },
             "run-async": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+              "dev": true,
+              "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+              },
               "dependencies": {
                 "once": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
                     }
                   }
                 }
               }
             },
             "rx-lite": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+              "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+              "dev": true
             },
             "string-width": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              },
               "dependencies": {
                 "code-point-at": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                  "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                  "dev": true
                 },
                 "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                  },
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
                     }
                   }
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+              }
             },
             "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+              "dev": true
             }
           }
         },
         "is-my-json-valid": {
-          "version": "2.16.0",
-          "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+          "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+          "dev": true,
+          "requires": {
+            "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          },
           "dependencies": {
             "generate-function": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+              "dev": true
             },
             "generate-object-property": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dev": true,
+              "requires": {
+                "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+              },
               "dependencies": {
                 "is-property": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                  "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                  "dev": true
                 }
               }
             },
             "jsonpointer": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+              "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+              "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+              "dev": true
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+              "dev": true
             }
           }
         },
         "is-resolvable": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+          "dev": true,
+          "requires": {
+            "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+          },
           "dependencies": {
             "tryit": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+              "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+              "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+              "dev": true
             }
           }
         },
         "js-yaml": {
-          "version": "3.8.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
+          "dev": true,
+          "requires": {
+            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+          },
           "dependencies": {
             "argparse": {
-              "version": "1.0.9",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+              },
               "dependencies": {
                 "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                  "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
                 }
               }
             },
             "esprima": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+              "dev": true
             }
           }
         },
         "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "requires": {
+            "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+          },
           "dependencies": {
             "jsonify": {
-              "version": "0.0.0",
-              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+              "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "dev": true
             }
           }
         },
         "levn": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+          },
           "dependencies": {
             "prelude-ls": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+              "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
             },
             "type-check": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+              "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+              }
             }
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
             }
           }
         },
         "natural-compare": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
+          "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+          "dev": true
         },
         "optionator": {
-          "version": "0.8.2",
-          "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+          "dev": true,
+          "requires": {
+            "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+          },
           "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-            },
             "deep-is": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+              "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+              "dev": true
             },
             "fast-levenshtein": {
-              "version": "2.0.6",
-              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+              "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+              "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+              "dev": true
+            },
+            "prelude-ls": {
+              "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
+            },
+            "type-check": {
+              "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+              }
+            },
+            "wordwrap": {
+              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "dev": true
             }
           }
         },
         "path-is-inside": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+          "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
         },
         "pluralize": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+          "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+          "dev": true
         },
         "progress": {
-          "version": "1.1.8",
-          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+          "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
         },
         "require-uncached": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+          "dev": true,
+          "requires": {
+            "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+          },
           "dependencies": {
             "caller-path": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+              "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+              "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+              "dev": true,
+              "requires": {
+                "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+              },
               "dependencies": {
                 "callsites": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+                  "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                  "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+                  "dev": true
                 }
               }
             },
             "resolve-from": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+              "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+              "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+              "dev": true
             }
           }
         },
         "shelljs": {
-          "version": "0.7.7",
-          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+          "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+          "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+          "dev": true,
+          "requires": {
+            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+            "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+          },
           "dependencies": {
             "interpret": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
+              "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+              "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+              "dev": true
             },
             "rechoir": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+              "dev": true,
+              "requires": {
+                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+              },
               "dependencies": {
                 "resolve": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+                  "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+                  "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+                  "dev": true,
+                  "requires": {
+                    "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+                  },
                   "dependencies": {
                     "path-parse": {
-                      "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+                      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+                      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+                      "dev": true
                     }
                   }
                 }
@@ -1136,61 +1653,80 @@
           }
         },
         "strip-bom": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         },
         "strip-json-comments": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         },
         "table": {
-          "version": "3.8.3",
-          "from": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+          "dev": true,
+          "requires": {
+            "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+            "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
+          },
           "dependencies": {
             "ajv": {
-              "version": "4.11.7",
-              "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+              "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.7.tgz",
+              "integrity": "sha1-hlWl2G0IJJhcxHGh2RP7Zymg7Eg=",
+              "dev": true,
+              "requires": {
+                "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+              },
               "dependencies": {
                 "co": {
-                  "version": "4.6.0",
-                  "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                  "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                  "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                  "dev": true
                 }
               }
             },
             "ajv-keywords": {
-              "version": "1.5.1",
-              "from": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
+              "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+              "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+              "dev": true
             },
             "slice-ansi": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+              "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+              "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+              "dev": true
             },
             "string-width": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+              "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+              "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              },
               "dependencies": {
                 "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                  "dev": true
                 },
                 "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                  },
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                      "dev": true
                     }
                   }
                 }
@@ -1199,825 +1735,1059 @@
           }
         },
         "text-table": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+          "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
         },
         "user-home": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+          },
           "dependencies": {
             "os-homedir": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true
             }
           }
         }
       }
     },
     "glob": {
-      "version": "7.1.1",
-      "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "requires": {
+        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      },
       "dependencies": {
         "fs.realpath": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "inflight": {
-          "version": "1.0.6",
-          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          },
           "dependencies": {
             "wrappy": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             }
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "minimatch": {
-          "version": "3.0.3",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+          },
           "dependencies": {
             "brace-expansion": {
-              "version": "1.1.7",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+              "requires": {
+                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+              },
               "dependencies": {
                 "balanced-match": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                  "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
                 },
                 "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 }
               }
             }
           }
         },
         "once": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          },
           "dependencies": {
             "wrappy": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
             }
           }
         },
         "path-is-absolute": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         }
       }
     },
     "handlebars": {
-      "version": "4.0.6",
-      "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz"
+      },
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
         },
         "optimist": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+          },
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
             "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+              "dev": true
+            },
+            "wordwrap": {
+              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+              "dev": true
             }
           }
         },
         "source-map": {
-          "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          },
           "dependencies": {
             "amdefine": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+              "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+              "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+              "dev": true
             }
           }
         },
         "uglify-js": {
-          "version": "2.8.22",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+          "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          },
           "dependencies": {
             "source-map": {
-              "version": "0.5.6",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+              "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+              "dev": true,
+              "optional": true
+            },
+            "uglify-to-browserify": {
+              "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+              "dev": true,
+              "optional": true
             },
             "yargs": {
-              "version": "3.10.0",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+              },
               "dependencies": {
                 "camelcase": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                  "dev": true,
+                  "optional": true
                 },
                 "cliui": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                    "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                    "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  },
                   "dependencies": {
                     "center-align": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                      },
                       "dependencies": {
                         "align-text": {
-                          "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                          },
                           "dependencies": {
                             "kind-of": {
-                              "version": "3.2.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                              "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                              },
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                  "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                  "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+                                  "dev": true,
+                                  "optional": true
                                 }
                               }
                             },
                             "longest": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                              "dev": true,
+                              "optional": true
                             },
                             "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                              "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
                         "lazy-cache": {
-                          "version": "1.0.4",
-                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
                     "right-align": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+                      },
                       "dependencies": {
                         "align-text": {
-                          "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                          },
                           "dependencies": {
                             "kind-of": {
-                              "version": "3.2.0",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
+                              "integrity": "sha1-tYq+TVwEStM3JqjBUltIz4kb/wc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                              },
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                  "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                  "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+                                  "dev": true,
+                                  "optional": true
                                 }
                               }
                             },
                             "longest": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                              "dev": true,
+                              "optional": true
                             },
                             "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                              "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                              "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         }
                       }
                     },
                     "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                  "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                  "dev": true,
+                  "optional": true
                 },
                 "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                  "dev": true,
+                  "optional": true
                 }
               }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             }
           }
         }
       }
     },
     "istanbul": {
-      "version": "0.4.5",
-      "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "dev": true,
+      "requires": {
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+      },
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+          "dev": true
         },
         "async": {
-          "version": "1.5.2",
-          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
         },
         "escodegen": {
-          "version": "1.8.1",
-          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+          "dev": true,
+          "requires": {
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+          },
           "dependencies": {
             "estraverse": {
-              "version": "1.9.3",
-              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+              "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+              "dev": true
             },
             "esutils": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+              "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+              "dev": true
             },
             "optionator": {
-              "version": "0.8.2",
-              "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+              "dev": true,
+              "requires": {
+                "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+              },
               "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
                 "deep-is": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                },
-                "levn": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+                  "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                  "dev": true
                 },
                 "fast-levenshtein": {
-                  "version": "2.0.6",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+                  "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                  "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+                  "dev": true
+                },
+                "levn": {
+                  "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                  "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                    "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                  }
+                },
+                "prelude-ls": {
+                  "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                  "dev": true
+                },
+                "type-check": {
+                  "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                  }
                 }
               }
             },
             "source-map": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+              },
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                  "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+                  "dev": true,
+                  "optional": true
                 }
               }
             }
           }
         },
         "esprima": {
-          "version": "2.7.3",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
         },
         "glob": {
-          "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          },
           "dependencies": {
             "inflight": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "requires": {
+                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              },
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                  "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
                 }
               }
             },
             "inherits": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
             },
             "minimatch": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+              },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.7",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                  "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                    "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "dev": true
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
                     }
                   }
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
             }
           }
         },
         "js-yaml": {
-          "version": "3.8.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+          "integrity": "sha1-M6BexIHIUMiHWSkWb+G+thxyh2Y=",
+          "dev": true,
+          "requires": {
+            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+          },
           "dependencies": {
             "argparse": {
-              "version": "1.0.9",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+              },
               "dependencies": {
                 "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                  "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
                 }
               }
             },
             "esprima": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+              "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+              "dev": true
             }
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
             }
           }
         },
         "nopt": {
-          "version": "3.0.6",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          }
         },
         "once": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          },
           "dependencies": {
             "wrappy": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true
             }
           }
         },
         "resolve": {
-          "version": "1.1.7",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+          "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
         },
         "supports-color": {
-          "version": "3.2.3",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          },
           "dependencies": {
             "has-flag": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
             }
           }
         },
         "which": {
-          "version": "1.2.14",
-          "from": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+          },
           "dependencies": {
             "isexe": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+              "dev": true
             }
           }
         },
         "wordwrap": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
         }
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "mocha": {
-      "version": "3.3.0",
-      "from": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
+      "version": "https://registry.npmjs.org/mocha/-/mocha-3.3.0.tgz",
+      "integrity": "sha1-0pt0KNP1LILi5l3x7LcGThqrv7U=",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+      },
       "dependencies": {
         "browser-stdout": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
+          "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+          "dev": true
         },
         "commander": {
-          "version": "2.9.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          },
           "dependencies": {
             "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+              "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+              "dev": true
             }
           }
         },
         "debug": {
-          "version": "2.6.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          },
           "dependencies": {
             "ms": {
-              "version": "0.7.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+              "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+              "dev": true
             }
           }
         },
         "diff": {
-          "version": "3.2.0",
-          "from": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
+          "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
         },
         "growl": {
-          "version": "1.9.2",
-          "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+          "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+          "dev": true
         },
         "json3": {
-          "version": "3.3.2",
-          "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+          "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+          "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+          "dev": true
         },
         "lodash.create": {
-          "version": "3.1.1",
-          "from": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+            "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+            "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+          },
           "dependencies": {
             "lodash._baseassign": {
-              "version": "3.2.0",
-              "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+              },
               "dependencies": {
                 "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                  "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
                 },
                 "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                    "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                    "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  },
                   "dependencies": {
                     "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
                     },
                     "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
                     },
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                      "dev": true
                     }
                   }
                 }
               }
             },
             "lodash._basecreate": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+              "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+              "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+              "dev": true
             },
             "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+              "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+              "dev": true
             }
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
             }
           }
         },
         "supports-color": {
-          "version": "3.1.2",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          },
           "dependencies": {
             "has-flag": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "nymag-fs": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.0.tgz",
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.8.3",
-          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.9",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                }
-              }
-            },
-            "esprima": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
             }
           }
         }
       }
     },
     "pre-commit": {
-      "version": "1.2.2",
-      "from": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "version": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+        "spawn-sync": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      },
       "dependencies": {
         "cross-spawn": {
-          "version": "5.1.0",
-          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+            "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+          },
           "dependencies": {
             "lru-cache": {
-              "version": "4.0.2",
-              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+              "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+              "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+              "dev": true,
+              "requires": {
+                "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+              },
               "dependencies": {
                 "pseudomap": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                  "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                  "dev": true
                 },
                 "yallist": {
-                  "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+                  "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                  "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                  "dev": true
                 }
               }
             },
             "shebang-command": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+              "dev": true,
+              "requires": {
+                "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+              },
               "dependencies": {
                 "shebang-regex": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                  "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                  "dev": true
                 }
               }
             }
           }
         },
         "spawn-sync": {
-          "version": "1.0.15",
-          "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+          "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+          "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+          "dev": true,
+          "requires": {
+            "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+            "os-shim": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+          },
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
-              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+              "dev": true,
+              "requires": {
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+              },
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                  "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
                 },
                 "readable-stream": {
-                  "version": "2.2.9",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                  "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                  "dev": true,
+                  "requires": {
+                    "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  },
                   "dependencies": {
                     "buffer-shims": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                      "dev": true
                     },
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
                     },
                     "isarray": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
                     },
                     "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
                     },
                     "string_decoder": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
+                      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                      "dev": true,
+                      "requires": {
+                        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                      }
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
                     }
                   }
+                },
+                "typedarray": {
+                  "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+                  "dev": true
                 }
               }
             },
             "os-shim": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+              "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+              "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+              "dev": true
             }
           }
         },
         "which": {
-          "version": "1.2.14",
-          "from": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+          },
           "dependencies": {
             "isexe": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+              "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+              "dev": true
             }
           }
         }
       }
     },
     "sinon": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
+      "version": "https://registry.npmjs.org/sinon/-/sinon-2.1.0.tgz",
+      "integrity": "sha1-4Fep0r8bMvXW3WJijKnuOWGwyvs=",
+      "dev": true,
+      "requires": {
+        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+        "formatio": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+        "lolex": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+        "native-promise-only": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+        "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+        "text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+      },
       "dependencies": {
         "diff": {
-          "version": "3.2.0",
-          "from": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
+          "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
         },
         "formatio": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz"
+          "version": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+          "dev": true,
+          "requires": {
+            "samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
+          }
         },
         "lolex": {
-          "version": "1.6.0",
-          "from": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz"
+          "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
         },
         "native-promise-only": {
-          "version": "0.8.1",
-          "from": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz"
+          "version": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+          "dev": true
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          },
           "dependencies": {
             "isarray": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
             }
           }
         },
         "samsam": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
+          "version": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+          "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+          "dev": true
         },
         "text-encoding": {
-          "version": "0.6.4",
-          "from": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz"
+          "version": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+          "dev": true
         },
         "type-detect": {
-          "version": "4.0.3",
-          "from": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+          "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+          "dev": true
         }
       }
     }


### PR DESCRIPTION
Browserify bundles modules by analyzing their static dependencies. It does not work with dynamic requires. We could use this library in our model.js and related files. This change removes dynamic requires and manually exports each util. It adds a test to ensure that each util is actually being exported.