### PR TITLE
Adds getListInstance function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install --save clay-utils
 * **getComponentInstance** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/getComponentInstance)
 * **getComponentName** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/getComponentName)
 * **getComponentVersion** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/getComponentVersion)
+* **getListInstance** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/getListInstance)
 * **getPageInstance** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/getPageInstance)
 * **getPageVersion** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/getPageVersion)
 * **isComponent** [(code|tests|docs)](https://github.com/nymag/clay-utils/tree/master/lib/isComponent)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports.getComponentName = require('./lib/getComponentName');
 module.exports.getComponentVersion = require('./lib/getComponentVersion');
 module.exports.getPageInstance = require('./lib/getPageInstance');
 module.exports.getPageVersion = require('./lib/getPageVersion');
+module.exports.getListInstance = require('./lib/getListInstance');
 module.exports.isComponent = require('./lib/isComponent');
 module.exports.isDefaultComponent = require('./lib/isDefaultComponent');
 module.exports.isPage = require('./lib/isPage');

--- a/lib/getListInstance/README.md
+++ b/lib/getListInstance/README.md
@@ -1,0 +1,17 @@
+### getPageInstance
+
+Get page instance from uri
+
+#### Params
+
+* `uri` _string_
+
+**Returns** _string|null_
+
+#### Example
+
+```js
+getPageInstance('nymag.com/scienceofus/pages/foobarbaz@published')
+//=> 'foobarbaz@published'
+
+```

--- a/lib/getListInstance/README.md
+++ b/lib/getListInstance/README.md
@@ -1,6 +1,6 @@
-### getPageInstance
+### getListInstance
 
-Get page instance from uri
+Get list instance from uri
 
 #### Params
 
@@ -11,7 +11,7 @@ Get page instance from uri
 #### Example
 
 ```js
-getPageInstance('nymag.com/scienceofus/pages/foobarbaz@published')
-//=> 'foobarbaz@published'
+getPageInstance('nymag.com/lists/foo')
+//=> 'foo'
 
 ```

--- a/lib/getListInstance/index.js
+++ b/lib/getListInstance/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const isUriStringCheck = require('../strCheck');
+
+/**
+ * First test if argument passed in is a String. If true, get list instance
+ * from URI. Otherwise, throw an error.
+ * @example /lists/foo returns "foo"
+ * @param  {string} uri
+ * @return {string|null}
+ */
+module.exports = function (uri) {
+  isUriStringCheck.strCheck(uri);
+  const result = /\/lists\/(.*)/.exec(uri);
+
+  return result && result[1];
+};

--- a/lib/getListInstance/index.test.js
+++ b/lib/getListInstance/index.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const name = __filename.split('/').pop().split('.').shift(),
+  fn = require('./' + name),
+  expect = require('chai').expect;
+
+describe('getListInstance', () => {
+
+  it('gets instance from uri', function () {
+    expect(fn('/lists/foo')).to.equal('foo');
+  });
+
+  it('CANNOT get instance from a non-list uri', function () {
+    expect(fn('/components/foo/instances/0')).to.equal(null);
+    expect(fn('/pages/foo')).to.equal(null);
+  });
+
+  it('throws an error if argument passed in is not a String', () => {
+    const nonStringArgument = function () {
+      return fn([1, 2, 3, 4]);
+    };
+
+    expect(nonStringArgument).to.throw(Error);
+  });
+});

--- a/lib/getListInstance/index.test.js
+++ b/lib/getListInstance/index.test.js
@@ -4,7 +4,7 @@ const name = __filename.split('/').pop().split('.').shift(),
   fn = require('./' + name),
   expect = require('chai').expect;
 
-describe('getListInstance', () => {
+describe('getListInstance', function () {
 
   it('gets instance from uri', function () {
     expect(fn('/lists/foo')).to.equal('foo');
@@ -15,7 +15,7 @@ describe('getListInstance', () => {
     expect(fn('/pages/foo')).to.equal(null);
   });
 
-  it('throws an error if argument passed in is not a String', () => {
+  it('throws an error if argument passed in is not a String', function () {
     const nonStringArgument = function () {
       return fn([1, 2, 3, 4]);
     };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-utils",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "dependencies": {
     "chai": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-utils",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A collection of utility functions for working with Clay.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds `getListInstance`, which returns the name of the list URL or URI that you pass into it.

Distantly related to [Trello](https://trello.com/c/Z0tqynOw/36-add-site-to-site-import-in-clay-cli)